### PR TITLE
Don't run discord notify action on forks

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Notify Discord (success)
       uses: appleboy/discord-action@master
+      if: github.repository == github.event.pull_request.head.repo.full_name
       with:
         webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
         webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
@@ -30,7 +31,7 @@ jobs:
 
     - name: Notify Discord (failure)
       uses: appleboy/discord-action@master
-      if: failure()
+      if: github.repository == github.event.pull_request.head.repo.full_name && failure()
       with:
         webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
         webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}


### PR DESCRIPTION
Fixes the unit test action failing in fork pull requests since forks don't have the Discord webhook token secret.